### PR TITLE
update FSRS-rs to v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "fsrs"
-version = "1.4.4"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e84a9389aceafb768b79cb53ad2e86cebf68ddd5391f136209fe6ad32d6c"
+checksum = "738a17a9825de16c23063c5931738e96aacce208a9b0ab54260c6ea2aa6a6feb"
 dependencies = [
  "burn",
  "itertools",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs-rs-python"
-version = "0.2.2"
+version = "0.6.0"
 dependencies = [
  "fsrs",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs-rs-python"
-version = "0.2.2"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ name = "fsrs_rs_python"
 crate-type = ["cdylib"]
 
 [dependencies.fsrs]
-version = "1.4.4"
+version = "1.5.0"
 # path = "../fsrs-rs"
 
 [dependencies]


### PR DESCRIPTION
The version of fsrs-rs-python is also updated to v0.6.0 to keep consistent with the tag in Git.