### PR TITLE
Fix/Autofix

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,7 +36,7 @@ jobs:
       - run: rustup toolchain install ${{ env.rust_clippy }} --profile minimal --component rustfmt --component clippy
       - run: rustup default ${{ env.rust_clippy }}
 
-      - run: cargo clippy --fix --workspace
+      - run: cargo clippy --fix --workspace --allow-dirty
       - run: cargo fmt --all
 
 


### PR DESCRIPTION
If the python gets reformatted, `cargo clippy --fix` can't run because git is dirty. https://github.com/open-spaced-repetition/fsrs-rs-python/actions/runs/14177364080/job/39715373920