### PR TITLE
[add] stability & difficulty getters for MemoryState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "fsrs-rs-python"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "fsrs",
  "macerator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrs-rs-python"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,14 @@ impl MemoryState {
             difficulty,
         })
     }
+    #[getter]
+    pub fn stability(&self) -> f32 {
+        self.0.stability
+    }
+    #[getter]
+    pub fn difficulty(&self) -> f32 {
+        self.0.difficulty
+    }
     pub fn __repr__(&self) -> String {
         format!("{:?}", self.0)
     }


### PR DESCRIPTION
Supposedly fixes #41 . Couldn't find tests to run but it compiles and new bindings work from Python.