### PR TITLE
Expose upstream FSRS default parameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,12 +249,6 @@ fn fsrs_rs_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<FSRSReview>()?;
     m.add_function(wrap_pyfunction!(simulate, m)?)?;
     m.add_function(wrap_pyfunction!(default_simulator_config, m)?)?;
-    m.add(
-        "DEFAULT_PARAMETERS",
-        [
-            0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192,
-            1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655, 0.6621,
-        ],
-    )?;
+    m.add("DEFAULT_PARAMETERS", fsrs::DEFAULT_PARAMETERS.to_vec())?;
     Ok(())
 }


### PR DESCRIPTION
Fixes #72.

## Summary

This updates the Python binding to expose `fsrs::DEFAULT_PARAMETERS` directly instead of keeping a manually inlined parameter list in `src/lib.rs`.

The current inlined list has 19 values, while the bundled `fsrs = "5.2.0"` crate exposes the current FSRS-6 defaults as 21 values.

## Why

The mismatch means:

- `len(fsrs_rs_python.DEFAULT_PARAMETERS)` is currently 19.
- `len(FSRS([]).compute_parameters(...))` can return 21.
- `FSRS(DEFAULT_PARAMETERS)` starts from legacy defaults even though the underlying `fsrs` crate already has the current 21-value defaults.

## Change

Replace the manually duplicated list with:

```rust
m.add("DEFAULT_PARAMETERS", fsrs::DEFAULT_PARAMETERS.to_vec())?;
```

This makes the binding follow the upstream Rust crate and prevents the exported defaults from drifting again.

## Verification

I could not run `cargo check` locally because Rust/Cargo is not installed in this environment.

The referenced symbol is publicly re-exported by `fsrs`:

```rust
pub use inference::{
    DEFAULT_PARAMETERS, FSRS5_DEFAULT_DECAY, FSRS6_DEFAULT_DECAY, ItemProgress, ItemState,
    MemoryState, ModelEvaluation, NextStates, current_retrievability,
    evaluate_with_time_series_splits,
};
```